### PR TITLE
Fixed location for Availability Set

### DIFF
--- a/vmseries-avset/azureDeploy.json
+++ b/vmseries-avset/azureDeploy.json
@@ -266,7 +266,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('availabilitySetName')]",
-      "location": "[resourceGroup().location]"
+      "location": "[parameters('location')]"
     }, 
     {
         "apiVersion": "[variables('apiVersion')]",


### PR DESCRIPTION
The Availability Set was being set by the Resource Group location. This meant that if you specified one region in the azureDeploy.parameters.json file but the Resource Group location was elsewhere, the deployment would fail due to the Availability Set being in a different location. The Availability Set now looks up the location parameter from the azureDeploy.parameters.json file and follows the location of the other resources.